### PR TITLE
Select Keil.NUCLEO-G474RE_BSP.2.0.0.pack

### DIFF
--- a/hello+NUCLEO-G474RE.cbuild-run.yml
+++ b/hello+NUCLEO-G474RE.cbuild-run.yml
@@ -5,7 +5,7 @@ cbuild-run:
   target-set: <default>
   compiler: AC6
   board: STMicroelectronics::NUCLEO-G474RE:Rev.C
-  board-pack: Keil::NUCLEO-G474RE_BSP@1.0.0
+  board-pack: Keil::NUCLEO-G474RE_BSP@2.0.0
   device: STMicroelectronics::STM32G474RETx
   device-pack: Keil::STM32G4xx_DFP@1.5.0
   output:

--- a/hello.cbuild-pack.yml
+++ b/hello.cbuild-pack.yml
@@ -9,7 +9,7 @@ cbuild-pack:
     - resolved-pack: ARM::CMSIS-RTX@5.9.0
       selected-by-pack:
         - ARM::CMSIS-RTX
-    - resolved-pack: Keil::NUCLEO-G474RE_BSP@1.0.0
+    - resolved-pack: Keil::NUCLEO-G474RE_BSP@2.0.0
       selected-by-pack:
         - Keil::NUCLEO-G474RE_BSP
     - resolved-pack: Keil::STM32G4xx_DFP@1.5.0


### PR DESCRIPTION
Select the Keil.NUCLEO-G474RE_BSP.2.0.0.pack version to solve the download error:
E: "https://www.keil.com/pack/Keil.NUCLEO-G474RE_BSP.1.0.0.pack": bad request
when downloading the Keil.NUCLEO-G474RE_BSP.1.0.0.pack.